### PR TITLE
Wrap Linux workflow steps in make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ jobs:
       - name: install prerequisites
         run: sudo apt-get update && sudo apt-get -y install debhelper devscripts libevent-dev
       - name: build .deb
-        run: |
-          sudo DEBUILD_DPKG_BUILDPACKAGE_OPTS="-r'fakeroot --faked faked-tcp' -us -uc" DEBUILD_LINTIAN_OPTS="-i -I --show-overrides" sudo debuild --no-conf -us -uc
-          make package
+        run: make debuild package
       - name: upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/Make.mk
+++ b/Make.mk
@@ -5,9 +5,41 @@ include Config.mk
 
 BUILD_RESULTS_DIR = build_results
 
-default: build
-
 .PHONY: clean download build install uninstall
+
+default: debuild package
+
+######################################################################################
+# These build steps are intended to be invoked manually with make
+
+debuild:
+	sudo DEBUILD_DPKG_BUILDPACKAGE_OPTS="-r'fakeroot --faked faked-tcp' -us -uc" DEBUILD_LINTIAN_OPTS="-i -I --show-overrides" sudo debuild --no-conf -us -uc
+
+package:
+	mkdir -p $(BUILD_RESULTS_DIR)
+	cp ../vasmm68k_*_amd64.deb $(BUILD_RESULTS_DIR)
+	(cd $(BUILD_RESULTS_DIR) && tar -cvf linux-deb-package.tgz vasmm68k_*_amd64.deb)
+	rm $(BUILD_RESULTS_DIR)/vasmm68k_*_amd64.deb
+
+######################################################################################
+# These build steps are not part of the build/package process; they allow for
+# easy local testing of a newly-built vasm without needing to install the .deb package
+
+install:
+	mkdir -p $(DESTDIR)/usr/bin
+	cp vasm/vasmm68k_mot $(DESTDIR)/usr/bin/
+	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_mot
+
+	cp vasm/vasmm68k_std $(DESTDIR)/usr/bin/
+	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_std
+
+uninstall:
+	rm -f /usr/bin/vasmm68k_mot
+	rm -f /usr/bin/vasmm68k_std
+
+######################################################################################
+# These build steps will be invoked by the 'debuild' tool; they are referenced in the debian/rules file
+# They can also be invoked manually with make
 
 clean:
 	rm -rf vasm
@@ -22,20 +54,3 @@ build:
 	(cd vasm && make CPU=m68k SYNTAX=mot && chmod ugo+rx vasmm68k_mot)
 	(cd vasm && make CPU=m68k SYNTAX=std && chmod ugo+rx vasmm68k_std)
 
-package:
-	mkdir -p $(BUILD_RESULTS_DIR)
-	cp ../vasmm68k_*_amd64.deb $(BUILD_RESULTS_DIR)
-	(cd $(BUILD_RESULTS_DIR) && tar -cvf linux-deb-package.tgz vasmm68k_*_amd64.deb)
-	rm $(BUILD_RESULTS_DIR)/vasmm68k_*_amd64.deb
-
-install:
-	mkdir -p $(DESTDIR)/usr/bin
-	cp vasm/vasmm68k_mot $(DESTDIR)/usr/bin/
-	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_mot
-
-	cp vasm/vasmm68k_std $(DESTDIR)/usr/bin/
-	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_std
-
-uninstall:
-	rm -f /usr/bin/vasmm68k_mot
-	rm -f /usr/bin/vasmm68k_std

--- a/Make.mk
+++ b/Make.mk
@@ -13,7 +13,7 @@ default: debuild package
 # These build steps are intended to be invoked manually with make
 
 debuild:
-	sudo DEBUILD_DPKG_BUILDPACKAGE_OPTS="-r'fakeroot --faked faked-tcp' -us -uc" DEBUILD_LINTIAN_OPTS="-i -I --show-overrides" sudo debuild --no-conf -us -uc
+	sudo DEBUILD_DPKG_BUILDPACKAGE_OPTS="-r'fakeroot --faked faked-tcp' -us -uc" DEBUILD_LINTIAN_OPTS="-i -I --show-overrides" debuild --no-conf -us -uc
 
 package:
 	mkdir -p $(BUILD_RESULTS_DIR)

--- a/Make.mk
+++ b/Make.mk
@@ -37,6 +37,7 @@ remove-deb:
 clean:
 	rm -rf vasm
 	rm -f vasm.tar.gz
+	rm -rf $(BUILD_RESULTS_DIR)
 
 download:
 	wget -O vasm.tar.gz $(VASM_URL)

--- a/Make.mk
+++ b/Make.mk
@@ -19,23 +19,16 @@ package:
 	mkdir -p $(BUILD_RESULTS_DIR)
 	cp ../vasmm68k_*_amd64.deb $(BUILD_RESULTS_DIR)
 	(cd $(BUILD_RESULTS_DIR) && tar -cvf linux-deb-package.tgz vasmm68k_*_amd64.deb)
-	rm $(BUILD_RESULTS_DIR)/vasmm68k_*_amd64.deb
 
 ######################################################################################
 # These build steps are not part of the build/package process; they allow for
-# easy local testing of a newly-built vasm without needing to install the .deb package
+# easy local testing of a newly-built .deb package
 
-install:
-	mkdir -p $(DESTDIR)/usr/bin
-	cp vasm/vasmm68k_mot $(DESTDIR)/usr/bin/
-	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_mot
+install-deb:
+	sudo dpkg -i $(BUILD_RESULTS_DIR)/vasmm68k_*_amd64.deb
 
-	cp vasm/vasmm68k_std $(DESTDIR)/usr/bin/
-	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_std
-
-uninstall:
-	rm -f /usr/bin/vasmm68k_mot
-	rm -f /usr/bin/vasmm68k_std
+remove-deb:
+	sudo dpkg -r vasmm68k
 
 ######################################################################################
 # These build steps will be invoked by the 'debuild' tool; they are referenced in the debian/rules file
@@ -54,3 +47,10 @@ build:
 	(cd vasm && make CPU=m68k SYNTAX=mot && chmod ugo+rx vasmm68k_mot)
 	(cd vasm && make CPU=m68k SYNTAX=std && chmod ugo+rx vasmm68k_std)
 
+install:
+	mkdir -p $(DESTDIR)/usr/bin
+	cp vasm/vasmm68k_mot $(DESTDIR)/usr/bin/
+	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_mot
+
+	cp vasm/vasmm68k_std $(DESTDIR)/usr/bin/
+	chmod ugo+rx $(DESTDIR)/usr/bin/vasmm68k_std

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ override_dh_auto_build:
 #override_dh_auto_test:
 #
 #override_dh_auto_install:
-#    make install
+#	make install
 
 override_dh_gencontrol:
 	dh_gencontrol -- -v$(PACKAGEVERSION)

--- a/debian/rules
+++ b/debian/rules
@@ -13,10 +13,10 @@ override_dh_auto_clean:
 	make clean
 	make download
 
+override_dh_auto_build:
+	make build
+
 #override_dh_auto_test:
-#
-#override_dh_auto_build:
-#    make build
 #
 #override_dh_auto_install:
 #    make install


### PR DESCRIPTION
There are no more long commandlines in build.yml. They are all in the makefile now. The 'install-deb' and 'remove-deb' auxiliary commands can be used when locally testing the newly-built package.

Clean removes build_results folder. Package does not remove .deb (since that would otherwise make install-deb more complicated than necessary).