### PR TITLE
Rename linux release artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ on:
 jobs:
   build-linux:
     name: Build for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
       - name: install prerequisites
         run: sudo apt-get update && sudo apt-get -y install debhelper devscripts libevent-dev
       - name: build .deb
-        run: make debuild package
+        run: DISTRIBUTION=xenial make debuild package
       - name: upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -54,6 +54,13 @@ jobs:
     timeout-minutes: 30
     needs: [build-linux, build-windows]
     steps:
+      - name: Get branch info
+        id: branch_name
+        run: |
+          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
+          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
+          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          # These can be accessed as ${{ steps.branch_name.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download linux-deb-package
         uses: actions/download-artifact@v1
         with:
@@ -78,8 +85,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./linux-deb-package/linux-deb-package.tgz
-          asset_name: linux-deb-package.tgz
+          asset_path: ./linux-deb-package/vasmm68k_${{ steps.branch_name.outputs.SOURCE_TAG }}-xenial_amd64.deb
+          asset_name: vasmm68k ${{ steps.branch_name.outputs.SOURCE_TAG }} for Ubuntu Xenial (AMD64)
           asset_content_type: application/gzip
       - name: Upload windows-binaries
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./linux-deb-package/vasmm68k_${{ steps.branch_name.outputs.SOURCE_VERSION }}-xenial_amd64.deb
-          asset_name: vasmm68k ${{ steps.branch_name.outputs.SOURCE_VERSION }} for Ubuntu Xenial (AMD64)
+          asset_name: vasmm68k_${{ steps.branch_name.outputs.SOURCE_VERSION }}-xenial_amd64.deb
           asset_content_type: application/gzip
       - name: Upload windows-binaries
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
           echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
           echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
           # These can be accessed as ${{ steps.branch_name.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download linux-deb-package
         uses: actions/download-artifact@v1
@@ -85,8 +86,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./linux-deb-package/vasmm68k_${{ steps.branch_name.outputs.SOURCE_TAG }}-xenial_amd64.deb
-          asset_name: vasmm68k ${{ steps.branch_name.outputs.SOURCE_TAG }} for Ubuntu Xenial (AMD64)
+          asset_path: ./linux-deb-package/vasmm68k_${{ steps.branch_name.outputs.SOURCE_VERSION }}-xenial_amd64.deb
+          asset_name: vasmm68k ${{ steps.branch_name.outputs.SOURCE_VERSION }} for Ubuntu Xenial (AMD64)
           asset_content_type: application/gzip
       - name: Upload windows-binaries
         uses: actions/upload-release-asset@v1.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # Ignore build artifacts
 /build_results
+
+# Ignore temporary config-file for make (used for sending commands Make.mk -> debuild -> debian/rules)
+ConfigDistribution.mk

--- a/Make.mk
+++ b/Make.mk
@@ -3,6 +3,10 @@
 
 include Config.mk
 
+ifeq ($(strip $(DISTRIBUTION)),)
+DISTRIBUTION := $(shell lsb_release -sr)
+endif
+
 BUILD_RESULTS_DIR = build_results
 
 .PHONY: clean download build install uninstall
@@ -17,15 +21,14 @@ debuild:
 
 package:
 	mkdir -p $(BUILD_RESULTS_DIR)
-	cp ../vasmm68k_*_amd64.deb $(BUILD_RESULTS_DIR)
-	(cd $(BUILD_RESULTS_DIR) && tar -cvf linux-deb-package.tgz vasmm68k_*_amd64.deb)
+	cp ../vasmm68k_$(VASM_VERSION)-$(DISTRIBUTION)_amd64.deb $(BUILD_RESULTS_DIR)
 
 ######################################################################################
 # These build steps are not part of the build/package process; they allow for
 # easy local testing of a newly-built .deb package
 
 install-deb:
-	sudo dpkg -i $(BUILD_RESULTS_DIR)/vasmm68k_*_amd64.deb
+	sudo dpkg -i $(BUILD_RESULTS_DIR)/vasmm68k_$(VASM_VERSION)-$(DISTRIBUTION)_amd64.deb
 
 remove-deb:
 	sudo dpkg -r vasmm68k

--- a/Make.mk
+++ b/Make.mk
@@ -4,7 +4,7 @@
 include Config.mk
 
 ifeq ($(strip $(DISTRIBUTION)),)
-DISTRIBUTION := $(shell lsb_release -sr)
+DISTRIBUTION := unknown
 endif
 
 BUILD_RESULTS_DIR = build_results
@@ -17,7 +17,12 @@ default: debuild package
 # These build steps are intended to be invoked manually with make
 
 debuild:
+	# ConfigDistribution.mk is used to make the DISTRIBUTION variable available within debian/rules
+	# It would be preferable to pass it via the command line, but I haven't figured out a way
+	#  to pass extra environment variables or defines through.
+	echo "DISTRIBUTION := $(DISTRIBUTION)" > ConfigDistribution.mk
 	sudo DEBUILD_DPKG_BUILDPACKAGE_OPTS="-r'fakeroot --faked faked-tcp' -us -uc" DEBUILD_LINTIAN_OPTS="-i -I --show-overrides" debuild --no-conf -us -uc
+	rm ConfigDistribution.mk
 
 package:
 	mkdir -p $(BUILD_RESULTS_DIR)

--- a/debian/rules
+++ b/debian/rules
@@ -2,8 +2,11 @@
 
 include Config.mk
 
-DISTRIBUTION = $(shell lsb_release -sr)
-PACKAGEVERSION = $(VASM_VERSION)-0~$(DISTRIBUTION)0
+ifeq ($(strip $(DISTRIBUTION)),)
+DISTRIBUTION := $(shell lsb_release -sr)
+endif
+
+PACKAGEVERSION = $(VASM_VERSION)-$(DISTRIBUTION)
 
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -2,12 +2,10 @@
 
 include Config.mk
 
-ifeq ($(strip $(DISTRIBUTION)),)
-DISTRIBUTION := $(shell lsb_release -sr)
-endif
+# Import DISTRIBUTION variable from wrapper makefile
+include ConfigDistribution.mk
 
 PACKAGEVERSION = $(VASM_VERSION)-$(DISTRIBUTION)
-
 
 %:
 	dh $@


### PR DESCRIPTION
Linux release artifact has a sensible .deb name now.

Closes #15.