### PR TITLE
Feature/nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,24 @@ on:
     branches:
       - '**'
 
+  repository_dispatch:
+
+    # build-nightly will trigger a build of nightly on master
+    #
+    # Syntax for invoking this trigger:
+    #
+    # USERNAME=<name> \
+    # PERSONAL_ACCESS_TOKEN=<token> \
+    # ORGANIZATION=<org> \
+    # REPOSITORY=<repo> \
+    # bash -c 'curl -XPOST -u $USERNAME:$PERSONAL_ACCESS_TOKEN \
+    #    -H "Accept: application/vnd.github.everest-preview+json" \
+    #    -H "Content-Type: application/json" \
+    #    "https://api.github.com/repos/$ORGANIZATION/$REPOSITORY/dispatches" \
+    #    --data "{\"event_type\" : \"build-nightly\" }"'
+    #
+    types: [build-nightly]
+
 #
 # The build jobs are organized into two phases:
 #
@@ -41,14 +59,45 @@ on:
 # The Publish phase only runs when a release has been triggered.
 
 jobs:
+  capture-global-environment-variables:
+    name: Capture shared environment variables
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Capture environment variables
+      run: |
+        touch global-environment-variables.sh
+        echo "echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}" >> global-environment-variables.sh
+        echo "echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}"" >> global-environment-variables.sh
+        echo "echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}" >> global-environment-variables.sh
+        echo "echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}" >> global-environment-variables.sh
+        echo "echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)" >> global-environment-variables.sh
+        echo "echo ::set-output name=BUILD_TYPE::${{ if (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/')) { 'RELEASE' } else { 'NIGHTLY' } }}" >> global-environment-variables.sh
+        chmod ugo+x global-environment-variables.sh
+        cp global-environment-variables.sh global-environment-variables.ps1
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: global-environment-variables
+        path: .
+
   extract-changelog:
     name: Extract changelog
-    runs-on: ubuntu-16.04
-    timeout-minutes: 30
+    needs: [capture-global-environment-variables]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v1
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download source
-        run: make clean download
+        run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make clean download
       - name: Extract changelog
         run: make extract-changelog
       - name: Upload artifacts
@@ -59,30 +108,28 @@ jobs:
 
   build-linux-deb:
     name: Build for Linux - .deb package
+    needs: [capture-global-environment-variables]
     runs-on: ubuntu-16.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
           sudo apt-get update && sudo apt-get -y install debhelper devscripts libevent-dev
       - name: Build executables
-        run: DISTRIBUTION=xenial make clean download build
+        run: DISTRIBUTION=xenial BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make clean download build
       - name: Create .deb package
-        run: DISTRIBUTION=xenial make package-deb
+        run: DISTRIBUTION=xenial BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make package-deb
       - name: Test .deb package
-        run: DISTRIBUTION=xenial make test-deb
-      - name: Extract changelog
-        run: make extract-changelog
+        run: DISTRIBUTION=xenial BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make test-deb
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -91,19 +138,19 @@ jobs:
 
   build-linux-linuxbrew:
     name: Build for Linux - Linuxbrew formula
+    needs: [capture-global-environment-variables]
     runs-on: ubuntu-16.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
           sudo apt-get update && sudo apt-get -y install jq
@@ -113,24 +160,33 @@ jobs:
           echo "::set-env name=HOMEBREW_REPOSITORY::${HOMEBREW_REPOSITORY}"
           echo "::add-path::${HOMEBREW_PREFIX}/bin"
           echo "::add-path::${HOMEBREW_PREFIX}/sbin"
-          brew tap ${{ steps.branch_info.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
+          brew tap ${{ steps.global_env.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
           # Hack: change permissions for library from 666 to 644 since the umask is not honored
           #  yet 'brew audit' requires 644 for the formula file on Linux
           # We change permissions for all taps, since brew will lowercase org folder names, so
           #  ...SOURCE_ORGANIZATION is not necessarily a valid folder name
           chmod -R go-w /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps
       - name: Update homebrew formula locally
-        run: make update-homebrew-formula-locally
+        run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make update-homebrew-formula-locally
       - name: Test homebrew formula
-        run: make test-homebrew-formula
+        run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make test-homebrew-formula
 
   build-windows:
     name: Build for Windows
+    needs: [capture-global-environment-variables]
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: .\global-environment-variables\global-environment-variables.ps1
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Build executables
         shell: powershell
         run: |
@@ -155,27 +211,27 @@ jobs:
 
   build-macosx-homebrew:
     name: Build for MacOSX - Homebrew formula
+    needs: [capture-global-environment-variables]
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
           brew install jq
-          brew tap ${{ steps.branch_info.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
+          brew tap ${{ steps.global_env.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
       - name: Update homebrew formula locally
-        run: make update-homebrew-formula-locally
+        run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make update-homebrew-formula-locally
       - name: Test homebrew formula
-        run: make test-homebrew-formula
+        run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make test-homebrew-formula
 
   publish-github:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/'))
@@ -185,15 +241,14 @@ jobs:
     needs: [extract-changelog, build-linux-deb, build-linux-linuxbrew, build-windows, build-macosx-homebrew]
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
           sudo apt-get update && sudo apt-get -y install jq
@@ -213,16 +268,16 @@ jobs:
         id: create_release
         uses: ncipollo/release-action@v1
         with:
-          name: ${{ steps.branch_info.outputs.SOURCE_VERSION }}
+          name: ${{ steps.global_env.outputs.SOURCE_VERSION }}
           draft: false
           bodyFile: changelog-artifacts/changelog-for-version.md
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "linux-deb-artifacts/vasmm68k_${{ steps.branch_info.outputs.SOURCE_VERSION }}_amd64.xenial.deb,windows-artifacts/vasmm68k-${{ steps.branch_info.outputs.SOURCE_VERSION }}-windows-binaries.zip,windows-artifacts/vasmm68k-${{ steps.branch_info.outputs.SOURCE_VERSION }}-windows-installer.msi"
+          artifacts: "linux-deb-artifacts/vasmm68k_${{ steps.global_env.outputs.SOURCE_VERSION }}_amd64.xenial.deb,windows-artifacts/vasmm68k-${{ steps.global_env.outputs.SOURCE_VERSION }}-windows-binaries.zip,windows-artifacts/vasmm68k-${{ steps.global_env.outputs.SOURCE_VERSION }}-windows-installer.msi"
           # # Disabled publishing of Chocolatey package for now.
           # # The file name is not based on VASM_VERSION but on VASM_PACKAGE_VERSION
           # #   and thus we need logic to translate SOURCE_VERSION from the former to the latter format to make this step work.
           # # Filename: 
-          # # windows-binaries/vasmm68k.${{ steps.branch_info.outputs.SOURCE_VERSION }}.nupkg
+          # # windows-binaries/vasmm68k.${{ steps.global_env.outputs.SOURCE_VERSION }}.nupkg
 
   publish-apt:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/'))
@@ -232,15 +287,14 @@ jobs:
     needs: [extract-changelog, build-linux-deb, build-linux-linuxbrew, build-windows, build-macosx-homebrew, publish-github]
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download linux-deb-artifacts
         uses: actions/download-artifact@v1
         with:
@@ -249,27 +303,26 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.APT_REPO__REPOSITORY_DISPATCH__TOKEN }}
-          repository: ${{ steps.branch_info.outputs.SOURCE_ORGANIZATION }}/apt
+          repository: ${{ steps.global_env.outputs.SOURCE_ORGANIZATION }}/apt
           event-type: add-deb-package
-          client-payload: '{ "download_url": "https://github.com/${{ steps.branch_info.outputs.SOURCE_ORGANIZATION }}/vasmm68k/releases/download/releases%2F${{ steps.branch_info.outputs.SOURCE_VERSION }}/vasmm68k_${{ steps.branch_info.outputs.SOURCE_VERSION }}_amd64.xenial.deb", "distribution": "xenial" }'
+          client-payload: '{ "download_url": "https://github.com/${{ steps.global_env.outputs.SOURCE_ORGANIZATION }}/vasmm68k/releases/download/releases%2F${{ steps.global_env.outputs.SOURCE_VERSION }}/vasmm68k_${{ steps.global_env.outputs.SOURCE_VERSION }}_amd64.xenial.deb", "distribution": "xenial" }'
 
   publish-homebrew:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/'))
     name: Publish to Homebrew tap
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [extract-changelog, build-linux-deb, build-linux-linuxbrew, build-windows, build-macosx-homebrew]
+    needs: [extract-changelog, build-linux-deb, build-linux-linuxbrew, build-windows, build-macosx-homebrew, publish-github]
     steps:
       - uses: actions/checkout@v1
-      - name: Get branch info
-        id: branch_info
-        run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
-          echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}
-          echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)
-          # These can be accessed as ${{ steps.branch_info.outputs.SOURCE_NAME }} etc in subsequent steps
+      - name: Download global environment variables artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: global-environment-variables
+      - name: Apply global environment variables to current job
+        id: global_env
+        run: ./global-environment-variables/global-environment-variables.sh
+        # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
           sudo apt-get update && sudo apt-get -y install jq
@@ -279,7 +332,7 @@ jobs:
           echo "::set-env name=HOMEBREW_REPOSITORY::${HOMEBREW_REPOSITORY}"
           echo "::add-path::${HOMEBREW_PREFIX}/bin"
           echo "::add-path::${HOMEBREW_PREFIX}/sbin"
-          brew tap ${{ steps.branch_info.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
+          brew tap ${{ steps.global_env.outputs.SOURCE_ORGANIZATION }}/prebuilt-amiga-dev-tools
           # Hack: change permissions for library from 666 to 644 since the umask is not honored
           #  yet 'brew audit' requires 644 for the formula file on Linux
           # We change permissions for all taps, since brew will lowercase org folder names, so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download source
         run: BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }} make clean download
@@ -112,7 +112,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
@@ -142,7 +142,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
@@ -178,7 +178,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: .\global-environment-variables\global-environment-variables.ps1
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Build executables
         shell: powershell
@@ -215,7 +215,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
@@ -240,7 +240,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |
@@ -286,7 +286,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Download linux-deb-artifacts
         uses: actions/download-artifact@v1
@@ -314,7 +314,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: ./global-environment-variables/global-environment-variables.sh
+        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Install prerequisites
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,22 +64,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - name: Capture environment variables
-      run: |
-        touch global-environment-variables.sh
-        echo "echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}" >> global-environment-variables.sh
-        echo "echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}"" >> global-environment-variables.sh
-        echo "echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}" >> global-environment-variables.sh
-        echo "echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}" >> global-environment-variables.sh
-        echo "echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${{ github.repository }} | cut -d / -f 1)" >> global-environment-variables.sh
-        echo "echo ::set-output name=BUILD_TYPE::${{ if (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/')) { 'RELEASE' } else { 'NIGHTLY' } }}" >> global-environment-variables.sh
-        chmod ugo+x global-environment-variables.sh
-        cp global-environment-variables.sh global-environment-variables.ps1
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: global-environment-variables
-        path: .
+      - uses: actions/checkout@v1
+      - name: Capture environment variables
+        run: |
+          ./linux/scripts/create-global-environment-variables-script.sh build_results "${GITHUB_REF}" "${{ github.repository }}" "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/releases/') }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: global-environment-variables
+          path: build_results
 
   extract-changelog:
     name: Extract changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,18 +184,18 @@ jobs:
         shell: powershell
         run: |
           .\windows\scripts\set-msvc-path.ps1
-          if ((Start-Process nmake.exe -ArgumentList clean,download,build -NoNewWindow -Wait -PassThru).ExitCode) { throw }
+          if ((Start-Process nmake.exe -ArgumentList BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }},clean,download,build -NoNewWindow -Wait -PassThru).ExitCode) { throw }
       - name: Create packages
         shell: powershell
         run: |
           .\windows\scripts\set-msvc-path.ps1
           .\windows\scripts\set-wix-path.ps1
-          if ((Start-Process nmake.exe -ArgumentList package -NoNewWindow -Wait -PassThru).ExitCode) { throw }
+          if ((Start-Process nmake.exe -ArgumentList BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }},package -NoNewWindow -Wait -PassThru).ExitCode) { throw }
       - name: Test packages
         shell: powershell
         run: |
           .\windows\scripts\set-msvc-path.ps1
-          if ((Start-Process nmake.exe -ArgumentList test-packages -NoNewWindow -Wait -PassThru).ExitCode) { throw }
+          if ((Start-Process nmake.exe -ArgumentList BUILD_TYPE=${{ steps.global_env.outputs.BUILD_TYPE }},test-packages -NoNewWindow -Wait -PassThru).ExitCode) { throw }
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
           name: global-environment-variables
       - name: Apply global environment variables to current job
         id: global_env
-        run: chmod ugo+x ./global-environment-variables/global-environment-variables.sh && ./global-environment-variables/global-environment-variables.sh
+        run: .\global-environment-variables\global-environment-variables.ps1
         # These can be accessed as ${{ steps.global_env.outputs.SOURCE_NAME }} etc in subsequent steps
       - name: Build executables
         shell: powershell

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,22 +1,24 @@
 
 name: Trigger Release
 
-# This trigger updates the repo's configuration new download URLs and version number,
+# This trigger updates the repo's configuration with new download URLs and version number,
 #   and then starts the build + release process.
 #
 # Syntax for invoking this trigger:
 #
-# USERNAME=<name> PERSONAL_ACCESS_TOKEN=<token> \
-# ORGANIZATION=<org> REPOSITORY=<repo>
-# VASM_URL=<source code URL> VASM_DOC_URL=<doc url> VASM_VERSION=<version> \
+# USERNAME=<name> \
+# PERSONAL_ACCESS_TOKEN=<token> \
+# ORGANIZATION=<org> \
+# REPOSITORY=<repo> \
+# VASM_RELEASE_URL=<source code URL> \
+# VASM_RELEASE_VERSION=<version> \
 # bash -c 'curl -XPOST -u $USERNAME:$PERSONAL_ACCESS_TOKEN \
 #    -H "Accept: application/vnd.github.everest-preview+json" \
 #    -H "Content-Type: application/json" \
 #    "https://api.github.com/repos/$ORGANIZATION/$REPOSITORY/dispatches" \
 #    --data "{\"event_type\" : \"update-config-and-publish-release\", \
-#             \"client_payload\" : { \"vasm_url\" : \"$VASM_URL\", \
-#                                    \"vasm_doc_url\" : \"$VASM_DOC_URL\", \
-#                                    \"vasm_version\" : \"$VASM_VERSION\" } }"'
+#             \"client_payload\" : { \"vasm_release_url\" : \"$VASM_RELEASE_URL\", \
+#                                    \"vasm_release_version\" : \"$VASM_RELEASE_VERSION\" } }"'
 
 on:
   repository_dispatch:
@@ -34,6 +36,6 @@ jobs:
           # The non-default token will make the push operations trigger new workflow runs in build.yml
           token: "${{ secrets.THIS_REPO__PUSH__TOKEN }}"
       - name: Update config
-        run: NEW_VASM_URL=${{ github.event.client_payload.vasm_url }} NEW_VASM_DOC_URL=${{ github.event.client_payload.vasm_doc_url }} NEW_VASM_VERSION=${{ github.event.client_payload.vasm_version }} make update-config
+        run: NEW_VASM_RELEASE_URL=${{ github.event.client_payload.vasm_release_url }} NEW_VASM_RELEASE_VERSION=${{ github.event.client_payload.vasm_release_version }} make update-config
       - name: Trigger new release
-        run: NEW_VASM_VERSION=${{ github.event.client_payload.vasm_version }} make release
+        run: make release

--- a/Config.mk
+++ b/Config.mk
@@ -1,4 +1,5 @@
 
-VASM_URL = http://server.owl.de/~frank/tags/vasm1_8f.tar.gz
+VASM_NIGHTLY_URL = http://sun.hasenbraten.de/vasm/daily/vasm.tar.gz
+VASM_RELEASE_URL = http://server.owl.de/~frank/tags/vasm1_8f.tar.gz
 VASM_DOC_URL = http://sun.hasenbraten.de/vasm/release/vasm.pdf
-VASM_VERSION = 1.8f
+VASM_RELEASE_VERSION = 1.8f

--- a/homebrew/Make.mk
+++ b/homebrew/Make.mk
@@ -5,10 +5,14 @@
 # These build steps are intended to be invoked manually with make
 
 update-homebrew-formula-locally:
+ifeq ($(strip $(BUILD_TYPE)),RELEASE)
 	./homebrew/scripts/update-homebrew-formula.sh "$(VASM_URL)" "$(VASM_VERSION)" false
+else
+	echo "Skipping homebrew formula update for NIGHTLY build type"
+endif
 
 test-homebrew-formula:
-	./homebrew/scripts/test-homebrew-formula.sh
+	./homebrew/scripts/test-homebrew-formula.sh "$(BUILD_TYPE)"
 
 ######################################################################################
 # These build steps are not part of the build process; they allow for

--- a/homebrew/scripts/install-homebrew-formula.sh
+++ b/homebrew/scripts/install-homebrew-formula.sh
@@ -2,11 +2,22 @@
 
 set -e
 
-if [ $# -ne 0 ]; then
- echo 1>&2 "Usage: $0"
- exit 1
+if [ $# -ne 1 ]; then
+    echo 1>&2 "Usage: $0 BUILD_TYPE"
+    exit 1
 fi
+
+BUILD_TYPE="$1"
 
 FORMULA=vasmm68k
 
-brew install ${FORMULA}
+if [[ ${BUILD_TYPE} == "RELEASE" ]]; then
+    INSTALL_OPTIONS=""
+elif [[ ${BUILD_TYPE} == "NIGHTLY" ]]; then
+    INSTALL_OPTIONS="--HEAD"
+else
+    echo 1>&2 "BUILD_TYPE must be set to RELEASE or NIGHTLY"
+    exit 1
+fi
+
+brew install ${FORMULA} ${INSTALL_OPTIONS}

--- a/homebrew/scripts/test-homebrew-formula.sh
+++ b/homebrew/scripts/test-homebrew-formula.sh
@@ -2,14 +2,25 @@
 
 set -e
 
-if [ $# -ne 0 ]; then
- echo 1>&2 "Usage: $0"
- exit 1
+if [ $# -ne 1 ]; then
+    echo 1>&2 "Usage: $0 BUILD_TYPE"
+    exit 1
 fi
+
+BUILD_TYPE="$1"
 
 FORMULA=vasmm68k
 
+if [[ ${BUILD_TYPE} == "RELEASE" ]]; then
+    INSTALL_OPTIONS=""
+elif [[ ${BUILD_TYPE} == "NIGHTLY" ]]; then
+    INSTALL_OPTIONS="--HEAD"
+else
+    echo 1>&2 "BUILD_TYPE must be set to RELEASE or NIGHTLY"
+    exit 1
+fi
+
 brew audit --strict ${FORMULA}
-brew install ${FORMULA}
+brew install ${FORMULA} ${INSTALL_OPTIONS}
 brew test ${FORMULA}
 brew uninstall ${FORMULA}

--- a/linux/Make.mk
+++ b/linux/Make.mk
@@ -3,24 +3,32 @@
 
 include Config.mk
 
+# DISTRIBUTION defaults to unknown
+
 ifeq ($(strip $(DISTRIBUTION)),)
 DISTRIBUTION := unknown
 endif
 
-# Ensure that VASM_URL, VASM_DOC_URL and VASM_VERSION can be overridden
-#  through the use of NEW_xxx environment variables.
-# These variables are used when calling 'make update-config'.
+# BUILD_TYPE defaults to NIGHTLY
 
-ifneq ($(strip $(NEW_VASM_URL)),)
-VASM_URL = $(NEW_VASM_URL)
+ifeq ($(strip $(BUILD_TYPE)),)
+BUILD_TYPE := NIGHTLY
 endif
 
-ifneq ($(strip $(NEW_VASM_DOC_URL)),)
-VASM_DOC_URL = $(NEW_VASM_DOC_URL)
-endif
+# Setup VASM_URL and VASM_VERSION to refer to either the release or nightly build
 
-ifneq ($(strip $(NEW_VASM_VERSION)),)
-VASM_VERSION = $(NEW_VASM_VERSION)
+ifeq ($(strip $(BUILD_TYPE)),RELEASE)
+VASM_URL := $(VASM_RELEASE_URL)
+VASM_VERSION := $(VASM_RELEASE_VERSION)
+else ifeq ($(strip $(BUILD_TYPE)),NIGHTLY)
+VASM_URL := $(VASM_NIGHTLY_URL)
+# It would be nice if we could have VASM_VERSION = "0.0.0" for nightly builds.
+# However, the .deb packaging flow does not have access to BUILD_TYPE or any local
+#  variables from Make.mk. Therefore, we use VASM_RELEASE_VERSION to keep
+#  the versioning consistent.
+VASM_VERSION := $(VASM_RELEASE_VERSION)
+else
+$(error BUILD_TYPE must be undefined, or set to NIGHTLY or RELEASE)
 endif
 
 
@@ -68,7 +76,7 @@ uninstall-deb:
 #  the Git repository and push to origin
 
 update-config:
-	./linux/scripts/update-config.sh "$(NEW_VASM_URL)" "$(NEW_VASM_DOC_URL)" "$(NEW_VASM_VERSION)"
+	./linux/scripts/update-config.sh "$(NEW_VASM_NIGHTLY_URL)" "$(NEW_VASM_RELEASE_URL)" "$(NEW_VASM_DOC_URL)" "$(NEW_VASM_RELEASE_VERSION)"
 
 release:
 	./linux/scripts/release.sh "$(VASM_VERSION)"

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -2,7 +2,11 @@
 
 include ../Config.mk
 
-PACKAGEVERSION = $(VASM_VERSION)
+# It would be nice if we could have VASM_VERSION = "0.0.0" for nightly builds.
+# However, the .deb packaging flow does not have access to BUILD_TYPE or any local
+#  variables from Make.mk. Therefore, we use VASM_RELEASE_VERSION to keep
+#  the versioning consistent.
+PACKAGEVERSION = $(VASM_RELEASE_VERSION)
 
 DESTDIR=debian/vasmm68k
 

--- a/linux/scripts/create-global-environment-variables-script.sh
+++ b/linux/scripts/create-global-environment-variables-script.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Example commandlines:
+# ./linux/scripts/create-global-environment-variables-script.sh build_results refs/heads/feature-branch prebuilt-amiga-dev-tools/vasmm68k false
+# ./linux/scripts/create-global-environment-variables-script.sh build_results refs/tags/releases/1.8f prebuilt-amiga-dev-tools/vasmm68k true
+
+if [ $# -ne 4 ]; then
+  echo 1>&2 "Usage: $0 BUILD_RESULTS_DIR GITHUB_REF GITHUB_REPOSITORY IS_RELEASE"
+  exit 1
+fi
+
+BUILD_RESULTS_DIR="$1"
+GITHUB_REF="$2"
+GITHUB_REPOSITORY="$3"
+IS_RELEASE="$4"
+
+OUTPUT_FILE_SHELL="${BUILD_RESULTS_DIR}/global-environment-variables.sh"
+OUTPUT_FILE_POWERSHELL="${BUILD_RESULTS_DIR}/global-environment-variables.ps1"
+
+mkdir -p "${BUILD_RESULTS_DIR}"
+
+echo "" > ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}" >> ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}" >> ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}" >> ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}" >> ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)" >> ${OUTPUT_FILE_SHELL}
+echo "echo ::set-output name=BUILD_TYPE::$( if [[ ${IS_RELEASE} != 'false' ]]; then echo 'RELEASE'; else echo 'NIGHTLY'; fi)" >> ${OUTPUT_FILE_SHELL}
+chmod ugo+x ${OUTPUT_FILE_SHELL}
+cp ${OUTPUT_FILE_SHELL} ${OUTPUT_FILE_POWERSHELL}

--- a/linux/scripts/create-global-environment-variables-script.sh
+++ b/linux/scripts/create-global-environment-variables-script.sh
@@ -20,11 +20,11 @@ OUTPUT_FILE_POWERSHELL="${BUILD_RESULTS_DIR}/global-environment-variables.ps1"
 mkdir -p "${BUILD_RESULTS_DIR}"
 
 echo "" > ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}" >> ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}" >> ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}" >> ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}" >> ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=SOURCE_ORGANIZATION::$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)" >> ${OUTPUT_FILE_SHELL}
-echo "echo ::set-output name=BUILD_TYPE::$( if [[ ${IS_RELEASE} != 'false' ]]; then echo 'RELEASE'; else echo 'NIGHTLY'; fi)" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}\"" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}\"" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}\"" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=SOURCE_VERSION::${GITHUB_REF#refs/tags/releases/}\"" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=SOURCE_ORGANIZATION::$(echo ${GITHUB_REPOSITORY} | cut -d / -f 1)\"" >> ${OUTPUT_FILE_SHELL}
+echo "echo \"::set-output name=BUILD_TYPE::$( if [[ ${IS_RELEASE} != 'false' ]]; then echo 'RELEASE'; else echo 'NIGHTLY'; fi)\"" >> ${OUTPUT_FILE_SHELL}
 chmod ugo+x ${OUTPUT_FILE_SHELL}
 cp ${OUTPUT_FILE_SHELL} ${OUTPUT_FILE_POWERSHELL}

--- a/linux/scripts/update-config.sh
+++ b/linux/scripts/update-config.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-if [ $# -ne 3 ]; then
- echo 1>&2 "Usage: $0 VASM_URL VASM_DOC_URL VASM_VERSION"
+if [ $# -ne 2 ]; then
+ echo 1>&2 "Usage: $0 VASM_RELEASE_URL VASM_RELEASE_VERSION"
  exit 1
 fi
 
-VASM_URL="$1"
-VASM_DOC_URL="$2"
-VASM_VERSION="$3"
+VASM_RELEASE_URL="$1"
+VASM_RELEASE_VERSION="$2"
 
 git fetch
 
@@ -20,13 +19,13 @@ fi
 
 # Disallow config update if the tag exists either locally or remotely
 
-if [[ `git tag -l releases/${VASM_VERSION}` ]]; then
-    echo "The releases/${VASM_VERSION} tag already exists locally. Cannot update config."
+if [[ `git tag -l releases/${VASM_RELEASE_VERSION}` ]]; then
+    echo "The releases/${VASM_RELEASE_VERSION} tag already exists locally. Cannot update config."
     exit 1
 fi
 
-if [[ `git ls-remote origin refs/tags/releases/${VASM_VERSION}` ]]; then
-    echo "The releases/${VASM_VERSION} tag already exists in origin. Cannot update config."
+if [[ `git ls-remote origin refs/tags/releases/${VASM_RELEASE_VERSION}` ]]; then
+    echo "The releases/${VASM_RELEASE_VERSION} tag already exists in origin. Cannot update config."
     exit 1
 fi
 
@@ -51,11 +50,10 @@ else
     exit 1
 fi
 
-echo "" > Config.mk
-echo "VASM_URL = ${VASM_URL}" >> Config.mk
-echo "VASM_DOC_URL = ${VASM_DOC_URL}" >> Config.mk
-echo "VASM_VERSION = ${VASM_VERSION}" >> Config.mk
+sed "s/^VASM_RELEASE_URL = \(.*\)/VASM_RELEASE_URL = ${VASM_RELEASE_URL}/; s/^VASM_RELEASE_VERSION = \(.*\)/VASM_RELEASE_VERSION = ${VASM_RELEASE_VERSION}/" < Config.mk > Config.mk2
+cp Config.mk2 Config.mk
+rm Config.mk2
 
 git add .
-git commit -m "Updated config.mk to version ${VASM_VERSION}"
+git commit -m "Updated config.mk to version ${VASM_RELEASE_VERSION}"
 git push

--- a/windows/NMake.mk
+++ b/windows/NMake.mk
@@ -1,7 +1,23 @@
 
 # Windows build script
 
-!include Config.mk
+!INCLUDE Config.mk
+
+!IF "$(BUILD_TYPE)" == "RELEASE"
+VASM_URL = "$(VASM_RELEASE_URL)"
+VASM_VERSION = "$(VASM_RELEASE_VERSION)"
+!MESSAGE RELEASE path used
+!ELSEIF "$(BUILD_TYPE)" == "NIGHTLY" || !DEFINED(BUILD_TYPE)
+VASM_URL = "$(VASM_NIGHTLY_URL)"
+# It would be nice if we could have VASM_VERSION = "0.0.0" for nightly builds.
+# However, the .deb packaging flow does not have access to BUILD_TYPE or any local
+#  variables from Make.mk. Therefore, we use VASM_RELEASE_VERSION to keep
+#  the versioning consistent.
+VASM_VERSION = "$(VASM_RELEASE_VERSION)"
+!MESSAGE NIGHTLY path used
+!ELSE 
+!MESSAGE BUILD_TYPE must be undefined, or set to NIGHTLY or RELEASE
+!ENDIF
 
 VASMDIR=vasm
 


### PR DESCRIPTION
Support building the codebase in two modes; nightly and release. These fetch sources from two different locations.

Building normally (just "make") will build nightly. There are repository dispatch triggers for each of nightly and release builds.

Nightly builds are using the VASM_RELEASE_VERSION instead of 0.0.0. This is due to the .deb packaging flow not having access to the BUILD_TYPE env variable.