### PR TITLE
If the GitHub Release already exists, update it instead of creating a…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,6 +259,7 @@ jobs:
           draft: false
           bodyFile: changelog-artifacts/changelog-for-version.md
           token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
           artifacts: "linux-deb-artifacts/vasmm68k_${{ steps.global_env.outputs.SOURCE_VERSION }}_amd64.xenial.deb,windows-artifacts/vasmm68k-${{ steps.global_env.outputs.SOURCE_VERSION }}-windows-binaries.zip,windows-artifacts/vasmm68k-${{ steps.global_env.outputs.SOURCE_VERSION }}-windows-installer.msi"
           # # Disabled publishing of Chocolatey package for now.
           # # The file name is not based on VASM_VERSION but on VASM_PACKAGE_VERSION


### PR DESCRIPTION
… new release/failing

This change makes the GitHub Release handling more-or-less idempotent.

Apt & homebrew repos may or may not like having the same build contributed over again. Let's leave those problems for later.